### PR TITLE
use interface for logger

### DIFF
--- a/photon/client.go
+++ b/photon/client.go
@@ -23,7 +23,7 @@ import (
 type Client struct {
 	options           ClientOptions
 	restClient        *restClient
-	logger            *log.Logger
+	logger            Logger
 	Endpoint          string
 	Status            *StatusAPI
 	Tenants           *TenantsAPI
@@ -83,7 +83,7 @@ type ClientOptions struct {
 
 // Creates a new photon client with specified options. If options
 // is nil, default options will be used.
-func NewClient(endpoint string, options *ClientOptions, logger *log.Logger) (c *Client) {
+func NewClient(endpoint string, options *ClientOptions, logger Logger) (c *Client) {
 	defaultOptions := &ClientOptions{
 		TaskPollTimeout:   30 * time.Minute,
 		TaskPollDelay:     100 * time.Millisecond,

--- a/photon/lightwave/oidcclient.go
+++ b/photon/lightwave/oidcclient.go
@@ -24,9 +24,26 @@ import (
 
 const tokenScope string = "openid offline_access"
 
+// Logger is an interface that extracts all the relevant methods of the stdlib logger.
+// But it allows for different logging libraries to be used as well.
+// There's no standard interface, this is the closest we get, unfortunately.
+type Logger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatalln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}
+
 type OIDCClient struct {
 	httpClient *http.Client
-	logger     *log.Logger
+	logger     Logger
 
 	Endpoint string
 	Options  *OIDCClientOptions
@@ -45,7 +62,7 @@ type OIDCClientOptions struct {
 	TokenScope string
 }
 
-func NewOIDCClient(endpoint string, options *OIDCClientOptions, logger *log.Logger) (c *OIDCClient) {
+func NewOIDCClient(endpoint string, options *OIDCClientOptions, logger Logger) (c *OIDCClient) {
 	if logger == nil {
 		logger = log.New(ioutil.Discard, "", log.LstdFlags)
 	}

--- a/photon/restclient.go
+++ b/photon/restclient.go
@@ -14,16 +14,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+// Logger is an interface that extracts all the relevant methods of the stdlib logger.
+// But it allows for different logging libraries to be used as well.
+// There's no standard interface, this is the closest we get, unfortunately.
+type Logger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatalln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}
+
 type restClient struct {
 	httpClient *http.Client
-	logger     *log.Logger
+	logger     Logger
 }
 
 type request struct {


### PR DESCRIPTION
Allow for different logging libraries to be used.
We use logrus for most things and with this change we don't have to bend over backwards to make it play nice with our tools