### PR TITLE
Fix README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	client := photon.NewClient("http://localhost:9080", nil, nil)
-	status, err := client.Status.Get()
+	status, err := client.System.GetSystemStatus()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -71,7 +71,7 @@ import (
 
 func main() {
 	client := photon.NewClient("http://localhost:9080", nil, nil)
-	status, err := client.Status.Get()
+	status, err := client.System.GetSystemStatus()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
According to the package spec,  
```golang

client.Status.Get()
```

should be  
```golang
client.System.GetSystemStatus()
```